### PR TITLE
Removing the copy manager allows autocomplete with paste to work

### DIFF
--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -240,21 +240,12 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     }
   });
 
-  var pluginOptions = {
-    clipboardCommandHandler: function(editCommand){
-      that._undoRedoBuffer.queueAndExecuteCommand.call(that._undoRedoBuffer,editCommand);
-    },
-    readOnlyMode : false,
-    includeHeaderWhenCopying : false
-  };
-
   this._frozenColumn = new Slick.Grid(this._frozenColumnTarget, this.frozenData,
                                       frozenColumn, frozenColumnOptions);
   this.grid = new Slick.Grid(this.target, this.data, sgCols, sgOptions);
 
   // don't select the active cell, otherwise cell navigation won't work
   this.grid.setSelectionModel(new Slick.CellSelectionModel({selectActiveCell: false}));
-  this.grid.registerPlugin(new Slick.CellExternalCopyManager(pluginOptions));
 
   // When a cell changes, update the server with the new cell information
   this.grid.onCellChange.subscribe(function(e, args) {


### PR DESCRIPTION
It seems that `CellExternalCopyManager` was prohibiting the autocomplete. `CellExternalCopyManager` is used to facilitate undo/redo. However, undo/redo appear to work without the copy manager so didn't see a reason to retain it.

Fixes #354.

![autocomplete](https://user-images.githubusercontent.com/474290/56329439-54c88100-6138-11e9-8997-c8124ff23df4.gif)
