### PR TITLE
Modified PlateViewer colors + Legend

### DIFF
--- a/labcontrol/gui/static/css/labcontrol.css
+++ b/labcontrol/gui/static/css/labcontrol.css
@@ -24,14 +24,18 @@ cursor: pointer;
 background-color: white;
 }
 
+#plate-map-legend-commented-box {
+    text-align: center;
+}
+
 /* Wells class */
 
-/* Commented cell (green ringed cell) */
+/* Commented cell (green text) */
 .well-commented {
     color: green;
 }
 
-/* Value in cell duplicated on current plate (yellow ringed cell) */
+/* Value in cell duplicated on current plate (purple ringed cell) */
 .well-duplicated {
     border: 2px solid purple;
 }

--- a/labcontrol/gui/static/css/labcontrol.css
+++ b/labcontrol/gui/static/css/labcontrol.css
@@ -25,20 +25,18 @@ background-color: white;
 }
 
 /* Wells class */
+
+/* Commented cell (green ringed cell) */
 .well-commented {
-    border: 2px solid green;
+    color: green;
 }
 
+/* Value in cell duplicated on current plate (yellow ringed cell) */
 .well-duplicated {
-    background: repeating-linear-gradient(
-        45deg,
-        #f2a4a4,
-        #f2a4a4 10px,
-        #edc9c9 10px,
-        #edc9c9 20px
-        ) !important;
+    border: 2px solid purple;
 }
 
+/* Value in cell has already been plated on another plate */
 .well-prev-plated {
     background: repeating-linear-gradient(
         45deg,
@@ -49,9 +47,26 @@ background-color: white;
         );
 }
 
+/* Value in cell is not a member of the attached studies */
 .well-unknown {
-    background: #ff0000;
-    color: white;
+    background: repeating-linear-gradient(
+        45deg,
+        #f2a4a4,
+        #f2a4a4 10px,
+        #edc9c9 10px,
+        #edc9c9 20px
+        );
+}
+
+/* Value in cell matches one or more members of the attached studies */
+.well-indeterminate {
+    background: repeating-linear-gradient(
+        45deg,
+        #f2f2a4,
+        #f2f2a4 10px,
+        #FFE4B5 10px,
+        #FFE4B5 20px
+        );
 }
 
 .comment-box {

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -159,31 +159,46 @@
 
     <div id='plate-map-div' class='spreadsheet-container'></div>
 
-    <!-- Plate map legend div -->
+    <!-- Plate map legend div
+        Note that well-unknown and well-prev-plated are mutually exclusive
+        while well-duplicated is not. A duplicated value can appear in the
+        plate and be valid, unknown, or previously plated on another plate. -->
     <div id='plate-map-legend'><h5>Plate map legend</h5>
         <div id='legend-rows' class='legend-container'>
           <section id='plate-map-legend-commented' class='legend-entry'>
-            <div id='plate-map-legend-commented-box' class='well-commented legend-patch'></div>
+            <div id='plate-map-legend-commented-box' class='well-commented legend-patch'><center>Specimen ID</center></div>
             <div id='plate-map-legend-commented-text' class='legend-text'>
-              <p> The plate well has a comment.</p>
+              <p> Plate well has an attached comment</p>
             </div>
           </section>
           <section id='plate-map-legend-duplicated' class='legend-entry'>
             <div id='plate-map-legend-duplicated-box' class='well-duplicated legend-patch'></div>
             <div id='plate-map-legend-duplicated-text' class='legend-text'>
-              <p> The Sample ID already exists on this plate.</p>
+              <p> Specimen ID duplicated on current plate</p>
             </div>
           </section>
           <section id='plate-map-legend-prev-plated' class='legend-entry'>
             <div id='plate-map-legend-prev-plated-box' class='well-prev-plated legend-patch'></div>
             <div id='plate-map-legend-prev-plated-text' class='legend-text'>
-              <p> The Sample ID has been plated previously on another plate.</p>
+              <p> Specimen ID plated previously on another plate</p>
             </div>
           </section>
           <section id='plate-map-legend-unknown' class='legend-entry'>
             <div id='plate-map-legend-unknown-box' class='well-unknown legend-patch'></div>
             <div id='plate-map-legend-unknown-text' class='legend-text'>
-              <p> The Sample ID does not currently exist in any studies.</p>
+              <p> Specimen ID is not a member of the attached studies</p>
+            </div>
+          </section>
+          <section id='plate-map-legend-indeterminate' class='legend-entry'>
+            <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
+            <div id='plate-map-legend-indeterminate-text' class='legend-text'>
+             <p> Specimen ID matches more than one member of the attached studies</p>
+            </div>
+          </section>
+          <section id='plate-map-legend-indeterminate' class='legend-entry' style="visibility: hidden">
+            <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
+            <div id='plate-map-legend-indeterminate-text' class='legend-text'>
+             <p> Specimen ID matches more than one member of the attached studies</p>
             </div>
           </section>
         </div>

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -160,13 +160,14 @@
     <div id='plate-map-div' class='spreadsheet-container'></div>
 
     <!-- Plate map legend div
-        Note that well-unknown and well-prev-plated are mutually exclusive
-        while well-duplicated is not. A duplicated value can appear in the
-        plate and be valid, unknown, or previously plated on another plate. -->
+        well-unknown, well-prev-plated, and well-indeterminate are mutually
+        exclusive. Well-duplicated is not mutually exclusive and cells can
+        be well-duplicated in addition to one of the three choices above.
+        Otherwise normal cells can also be well-duplicated. -->
     <div id='plate-map-legend'><h5>Plate map legend</h5>
         <div id='legend-rows' class='legend-container'>
           <section id='plate-map-legend-commented' class='legend-entry'>
-            <div id='plate-map-legend-commented-box' class='well-commented legend-patch'><center>Specimen ID</center></div>
+            <div id='plate-map-legend-commented-box' class='well-commented legend-patch'>Specimen ID</div>
             <div id='plate-map-legend-commented-text' class='legend-text'>
               <p> Plate well has an attached comment</p>
             </div>
@@ -195,6 +196,8 @@
              <p> Specimen ID matches more than one member of the attached studies</p>
             </div>
           </section>
+          <!-- Hidden section added to populate a full row; otherwise, Well
+              comments will not be left-justified. -->
           <section id='plate-map-legend-indeterminate' class='legend-entry' style="visibility: hidden">
             <div id='plate-map-legend-indeterminate-box' class='well-indeterminate legend-patch'></div>
             <div id='plate-map-legend-indeterminate-text' class='legend-text'>


### PR DESCRIPTION
Text for invalid specimen ids implied id would not exist across all
studies, when it's only against the studies associated with the plate.

Added a new yellow candy-cane/barber-bar to represent a cell that was
populated using a multiselect paste and has more than one possible
specimen ID match across the attached studies. This is so the user can
be alerted, click on the cell, and select from the drop-down that should
appear.

Modified the colors to be more appealing. Looking for collective
feedback. Bold red is gone, and an invalid specimen ID is now the red
candy-cane color. Blue candy-cane color is the same as before,
representing a specimen ID that has already been plated on another
plate.

A new Yellow/Orange candy-cane stripe identifies values that match more
than one possible specimen ID from the attached studies.

The candy-cane types are mutually exclusive; a cell can't be both valid
and invalid (0 possible matches), invalid and matching 2 or more
possible specimen ids, etc.

However, any of the above types can still have duplicate entries on the
current plate. Hence, the platemapper now identifies duplicate entries
by wrapping the cell in a purple border. This way, there doesn't have to
be a hierarchy defining which error should be presented over another,
and it won't be random based on implementation.

Lastly, as the purple border can overwrite the green border for a cell
with comment, cells with comments will now have green lettering, rather
than a green border.

![new_legend](https://user-images.githubusercontent.com/42684307/63205219-61150a00-c056-11e9-98e7-98de8bd65988.jpg)