### PR TITLE
Add a checkbox that allows autocomplete-from-paste and multiselect functionality to coexist; resolve duplicate plate issue

### DIFF
--- a/labcontrol/gui/static/js/plate.js
+++ b/labcontrol/gui/static/js/plate.js
@@ -115,7 +115,6 @@ function change_plate_configuration() {
   } else {
     // reset the container before updating the grid configuration
     $('#plate-map-div').empty().height(0);
-    pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
     // Enable the plate create button now that a plate config is selected
     $('#createPlateBtn').prop('disabled', false);
   }

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -255,14 +255,6 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   // don't select the active cell, otherwise cell navigation won't work
   this.grid.setSelectionModel(new Slick.CellSelectionModel({selectActiveCell: false}));
 
-  // TODO: This function is called twice every time an event happens, and that
-  // is because this binding is applied twice (because this initialize()
-  // function is called twice). This is likely worth addressing -- there are
-  // multiple ways to circumvent this -- but I'm not sure what would be best.
-  //   Idea 1: add this binding at the bottom of the plate HTML template
-  //   Idea 2: add logic to detect if this binding already exists (buggy?)
-  //   Idea 3: ignore this, and just accept that the callback will be called
-  //          twice (...is this intended?)
   $('#multiSelectCheckbox').on('change', function() {
     // In this callback function, "this" is the m.s. checkbox's <input> element
     // "that" is defined as this (see the start of this function), which lets

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -271,9 +271,20 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   // This paradigm inspired by
   // https://github.com/mleibman/SlickGrid/blob/master/examples/example-spreadsheet.html
   this.cellExternalCopyManager = new Slick.CellExternalCopyManager(pluginOptions);
-  // TODO: if the user navigates *back* to this page while this plugin is
-  // disabled, I think this will cause problems (analogous to issue #562).
-  this.grid.registerPlugin(this.cellExternalCopyManager);
+
+  // Whether or not we register the CECM plugin depends on whether or not the
+  // corresponding checkbox is checked. This should normally be true by
+  // default, but it's possible that the user could e.g. navigate "back" or
+  // "forward" to this page while the checkbox is unchecked.
+  //
+  // We make the choice here to respect that, instead of another workaround
+  // like using $(document).ready() to always ensure that the checkbox starts
+  // out checked. Either choice is valid -- this one just ensures that the JS
+  // code for handling this checkbox is mostly localized to one place (here),
+  // which should make life a little bit easier for us :)
+  if ($('#multiSelectCheckbox').prop('checked')) {
+    this.grid.registerPlugin(this.cellExternalCopyManager);
+  }
 
   // When a cell changes, update the server with the new cell information
   this.grid.onCellChange.subscribe(function(e, args) {

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -263,15 +263,16 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   //   Idea 2: add logic to detect if this binding already exists (buggy?)
   //   Idea 3: ignore this, and just accept that the callback will be called
   //          twice (...is this intended?)
-  // NOTE: We use a closure to pass "this" to the callback function
-  var currViewer = this;
   $('#multiSelectCheckbox').on('change', function() {
     // In this callback function, "this" is the m.s. checkbox's <input> element
+    // "that" is defined as this (see the start of this function), which lets
+    // us refer to this particular PlateViewer object from within callback
+    // functions like this one.
     if (this.checked) {
-      currViewer.grid.registerPlugin(currViewer.cellExternalCopyManager);
+      that.grid.registerPlugin(that.cellExternalCopyManager);
       // console.log("cecm plugin registered");
     } else {
-      currViewer.grid.unregisterPlugin(currViewer.cellExternalCopyManager);
+      that.grid.unregisterPlugin(that.cellExternalCopyManager);
       // console.log("cecm plugin UNregistered");
     }
   });

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -146,6 +146,13 @@
       <h6>When your cursor is focused on a cell in the plate map:</h6>
       <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
       <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
+      <p>
+        <input id="multiSelectCheckbox" type="checkbox" checked="checked">
+            <label for="multiSelectCheckbox">
+                Enable pasting from an external spreadsheet
+                (disables autocomplete on pasting IDs)
+            </label>
+      </p>
       <p>To add new Control types, go to <a target='_blank' href="/sample/manage_controls">Admin > Manage control sample types</a></p>
         <table>
           {% for cd in controls_description %}

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -143,6 +143,7 @@
 
     <!-- Controls div -->
     <div><h5>Controls description</h5>
+      <h6>When your cursor is focused on a cell in the plate map:</h6>
       <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
       <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
       <p>To add new Control types, go to <a target='_blank' href="/sample/manage_controls">Admin > Manage control sample types</a></p>

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -147,7 +147,7 @@
       <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
       <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
       <p>
-        <input id="multiSelectCheckbox" type="checkbox" checked="checked">
+        <input id="multiSelectCheckbox" type="checkbox" checked>
             <label for="multiSelectCheckbox">
                 Enable pasting from an external spreadsheet
                 (disables autocomplete on pasting IDs)

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -143,7 +143,6 @@
 
     <!-- Controls div -->
     <div><h5>Controls description</h5>
-      <h6>When your cursor is focused on a cell in the plate map:</h6>
       <p>Press <kbd class='key'>ESC</kbd> to enter cell <i>selection mode</i></p>
       <p>Press <kbd class='key'>ENTER</kbd> or double click a cell to enter <i>edit mode</i></p>
       <p>


### PR DESCRIPTION
Closes #354 and closes #567, and represents partial progress on #553. Details:

## Adding a checkbox that allows autocomplete and multiselect functionality to coexist
This PR implements the solution described by @wasade in #464. It's a pretty simple solution, thankfully.

Note that this checkbox defaults to "checked" (i.e. multiselect pasting is enabled, at the expense of the autocomplete popping up on pasting). _However_, if the page loads and the checkbox isn't checked (due to browser back/forward button shenanigans analogous to those causing #562), then my code respects that and holds off on registering the CECM plugin accordingly.

Something worth noting is that testing this on the 384-well plates is an ...interesting experience, because the autocomplete takes a few seconds to activate when pasting something in for a given cell. (But it does show up eventually.) Improving the autocomplete performance seems out of the scope of this PR, however.

## Resolve duplicate plate issue
This removes one line of code in `plate.js`, and thereby closes #567. (I was surprised fixing this was as easy as that, so I'm suspicious that this actually solves the issue that @antgonza and @wasade were apparently experiencing a while back. Not sure how to go about testing that that issue is actually resolved, though.)

## In any case
That's it for now! Thanks in advance for reviewing this PR, and happy to meet to discuss this in person tomorrow if that'd be easier.